### PR TITLE
FEATURE: FET-390 Move package under NPM @gooddata org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 tmp
 .DS_Store
+.idea

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,15 +1,3 @@
-stylelint-config-gooddata
+Copyright © GoodData Corporation 2019, All rights reserved
 
-BSD License
-
-Copyright (c) 2017, GoodData Corporation. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted, provided that the following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-    3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+No license granted.  Unauthorized copying, modification, distribution, or use of this file is strictly prohibited.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
-# .gooddata-css-style-guide {
+# @gooddata/stylelint-config
 
-Install
-
-`yarn install --save-dev stylelint-config-gooddata`
-
-.stylelintrc
+## Usage
+Add and install the library as development dependency:
+```
+    yarn install --save-dev @gooddata/stylelint-config
+```
+Modify your `.stylelintrc` configuration file:
 ```
 {
-  "extends": ["stylelint-config-gooddata"]
+  "extends": ["@gooddata/stylelint-config"]
 }
 ```
 
-# }
+## Library release
+
+Package publishing is done via Jenkins Job:
+
+[https://checklist.intgdc.com/job/client-libs/job/gooddata-css-style-release/](https://checklist.intgdc.com/job/client-libs/job/gooddata-css-style-release/)
+
+## License
+Copyright © GoodData Corporation 2020, All rights reserved
+
+No license granted.  Unauthorized copying, modification, distribution, or use of this file is strictly prohibited.  
+

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stylelint-config-gooddata",
+  "name": "@gooddata/stylelint-config",
   "version": "3.0.1",
   "description": "GoodData CSS Style Guide",
   "main": ".stylelintrc",
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/gooddata/gdc-css-style.git"
   },
-  "author": "Nikola Cech <nikola.cech@gooddata.com>",
+  "author": "GoodData Corporation",
   "license": "SEE LICENSE IN LICENSE.txt",
   "bugs": {
     "url": "https://github.com/gooddata/gdc-css-style/issues"


### PR DESCRIPTION
The move under the organization requires package to be scoped by "@gooddata/" prefix, i.e., the package must be renamed. The name was chosen to match our tslint and eslint package names. Additionally, the license and readme file was updated to match the latest standards approved by our Legal department.